### PR TITLE
fix GCP03 lidar yaw bias

### DIFF
--- a/individual_params/config/GCP03/aip_aichallenge/sensor_kit_calibration.yaml
+++ b/individual_params/config/GCP03/aip_aichallenge/sensor_kit_calibration.yaml
@@ -5,4 +5,4 @@ sensor_kit_base_link:
     z: 0.0378
     roll: 0.0
     pitch: 0.0
-    yaw: 0.0
+    yaw: -0.016


### PR DESCRIPTION
## Description

Fix GCP03 lidar yaw bias to -0.016

![image](https://github.com/tier4/autoware_individual_params.ai_challenge/assets/38061530/c7339e79-84f1-4975-ae69-39c58d8673a3)


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
